### PR TITLE
Add tile size info to artist tiles

### DIFF
--- a/public/app/views/festivalList.js
+++ b/public/app/views/festivalList.js
@@ -25,6 +25,21 @@ angular.module('FestivalListView', ['ngMaterial'])
                     }
                 }
                 res[i].tileInfo = tileInfo;
+                for (var j = 0; j < res[i].artists.length; j++) {
+                    var artistTileInfo = {
+                        ID: j,
+                        selected: false,
+                        defaultSpan: {
+                            cols: 2,
+                            rows: 2
+                        },
+                        displaySpan: {
+                            cols: 2,
+                            rows: 2
+                        }
+                    }
+                    res[i].artists[j].tileInfo = artistTileInfo;
+                }
             }
 
             $scope.eventList = res;

--- a/views/festivalMap.html
+++ b/views/festivalMap.html
@@ -69,10 +69,10 @@
 
 			                        <!-- Each artist is  a tile in the tileRow -->
 			                        <md-grid-tile
-			                            md-rowspan="{{artist.layout.span.row}}"
-			                            md-colspan="{{artist.layout.span.col}}"
-			                            md-colspan-sm="1"
 			                            ng-repeat="artist in event.artists | limitTo:8"
+			                            md-rowspan="{{artist.tileInfo.displaySpan.rows}}"
+			                            md-colspan="{{artist.tileInfo.displaySpan.cols}}"
+			                            md-colspan-sm="1"
 			                            class="artistTile">
 			                            <div style="width: 100%; height: 100%;" ng-style="{'background-image' :'url({{artist.image}})'}">			                            	
 			                            </div>


### PR DESCRIPTION
- All artist tiles set to 2 rows, 2 cols for now.
- Data stored in artist.tileInfo.displaySize.rows & artist.tileInfo.displaySize.cols
