### PR TITLE
Improve performance of chip search, closes #49

### DIFF
--- a/public/app/views/festivalList/festivalList.js
+++ b/public/app/views/festivalList/festivalList.js
@@ -142,6 +142,7 @@ angular.module('FestivalListView', ['ngMaterial'])
             var events;
             var artists;
             var results; 
+
             events = query ? $scope.eventList.filter($scope.createEventFilterFor(query)) : [];
             events = events.map(function (event) {
                 //Allows HTML to display 'name' and 'type' values in chips
@@ -192,6 +193,7 @@ angular.module('FestivalListView', ['ngMaterial'])
             return ((now - $scope.lastSearch) < 300);
         };
 
+        // Seach completed, refresh debounce
         $scope.refreshDebounce = function () {
             $scope.lastSearch = 0;
             $scope.searching = false;

--- a/public/app/views/festivalList/festivalList.js
+++ b/public/app/views/festivalList/festivalList.js
@@ -1,6 +1,6 @@
 angular.module('FestivalListView', ['ngMaterial'])
-    .controller('FestivalListCtrl', ['$scope', 'FestivalDataService', '$interval', '$q', '$timeout',
-        function ($scope, FestivalDataService, $interval, $q, $timeout) {
+    .controller('FestivalListCtrl', ['$scope', 'FestivalDataService', '$interval', '$q',
+        function ($scope, FestivalDataService, $interval, $q) {
 
         // Holds all info for all events we show in the events list
         $scope.eventList;

--- a/public/app/views/festivalList/festivalList.js
+++ b/public/app/views/festivalList/festivalList.js
@@ -1,5 +1,6 @@
 angular.module('FestivalListView', ['ngMaterial'])
-    .controller('FestivalListCtrl', ['$scope', 'FestivalDataService', '$interval', function ($scope, FestivalDataService, $interval) {
+    .controller('FestivalListCtrl', ['$scope', 'FestivalDataService', '$interval', '$q', '$timeout',
+        function ($scope, FestivalDataService, $interval, $q, $timeout) {
 
         // Holds all info for all events we show in the events list
         $scope.eventList;
@@ -7,6 +8,11 @@ angular.module('FestivalListView', ['ngMaterial'])
         $scope.currentlySelectedEventTile = -1;
 
         $scope.eventsLoaded = false;
+
+        $scope.pendingSearch;
+        $scope.searching = false;
+        $scope.cancelSearch = angular.noop;
+        $scope.lastSearch;
 
         $scope.selectedChips = [];
         $scope.selectedChip = null;
@@ -113,12 +119,29 @@ angular.module('FestivalListView', ['ngMaterial'])
             return display;
         };
 
+        // Performs chipSearch asynchronously so as not to hang the browser
+        $scope.asyncChipSearch = function (query) {
+
+            // Only perform a new search if there isn't one already happening
+            if ( !$scope.searching || !$scope.debounceSearch() ) {
+                $scope.cancelSearch();
+                // Run chipSearch async
+                return $scope.pendingSearch = $q(function(resolve, reject) {
+
+                    $scope.cancelSearch = reject;
+                    resolve( $scope.chipSearch(query) );
+                    $scope.refreshDebounce();
+                });
+            }
+            return $scope.pendingSearch;
+        };
+
         //Function to filter events and artist lists and show autocomplete suggestions for chip search
         $scope.chipSearch = function (query) {
+            $scope.searching = true;
             var events;
             var artists;
             var results; 
-            
             events = query ? $scope.eventList.filter($scope.createEventFilterFor(query)) : [];
             events = events.map(function (event) {
                 //Allows HTML to display 'name' and 'type' values in chips
@@ -133,7 +156,7 @@ angular.module('FestivalListView', ['ngMaterial'])
             });
             results = events.concat(artists);
             //RESULTS COULD BE SORTED BY SOME VALUE HERE?
-            return results;
+            return results.slice(0,10);
         };
 
         //Filters the eventlist for events (or artists within that event) matching a query
@@ -160,6 +183,19 @@ angular.module('FestivalListView', ['ngMaterial'])
             return function filterFn(artist) {
                 return (angular.lowercase(artist.name).indexOf(lowerCaseQuery) !== -1);
             }; 
+        };
+
+        // Debounce search if querying faster than 300ms
+        $scope.debounceSearch = function () {
+            var now = new Date().getMilliseconds();
+            $scope.lastSearch = $scope.lastSearch || now;
+            return ((now - $scope.lastSearch) < 300);
+        };
+
+        $scope.refreshDebounce = function () {
+            $scope.lastSearch = 0;
+            $scope.searching = false;
+            $scope.cancelSearch = angular.noop;
         };
         
         // When a tile is selected, tell the prev selected to collapse          

--- a/public/app/views/header/header.html
+++ b/public/app/views/header/header.html
@@ -11,7 +11,7 @@
             <md-autocomplete id="search-autocomplete"
                 md-selected-item="selectedChip"
                 md-search-text="searchText"
-                md-items="item in chipSearch(searchText)"
+                md-items="item in asyncChipSearch(searchText)"
                 md-item-text="item.name"
                 placeholder="Search for a festival, artist or event">
                 <span


### PR DESCRIPTION
- Now performs event & artist lookup asynchronously
- Only returns max 10 items, so as not to slow the rendering of the search list on the client
