### PR TITLE
Cache event data on first request, closes #46

### DIFF
--- a/controllers/events.js
+++ b/controllers/events.js
@@ -7,6 +7,8 @@ var fs = require('fs');
 // var contents = fs.readFileSync(__dirname + '/../config/api_keys.json');
 // var api_keys = JSON.parse(contents);
 
+var cachedEventData = null;
+
 // Serve requests to the event endpoint
 router.get('/event', function(req, res){
 
@@ -19,28 +21,37 @@ router.get('/event', function(req, res){
         // 'All' returns the entire events list
         if(req.query.type === "all") {
 
-            //Get all events from Skiddle API
-            var options = { method: 'GET',
-              url: process.env.skiddle_url  + 'events/',
-              qs: 
-               { eventcode: 'FEST',
-                 order: '4',
-                 api_key: process.env.skiddle_api_key } };
+            // Check to see if we've already cached the event data
+            if (!cachedEventData) {
+                //Get all events from Skiddle API
+                var options = { method: 'GET',
+                  url: process.env.skiddle_url  + 'events/',
+                  qs: 
+                   { eventcode: 'FEST',
+                     order: '4',
+                     api_key: process.env.skiddle_api_key } };
 
-            console.log("GET " + options.url);
+                console.log("GET " + options.url);
 
-            //Send the request
-            request(options, function (error, reqResponse, body) {
-              if (error) throw new Error(error);
-              var contents = JSON.parse(body);
-              if (contents.error !== 0) {
-                console.log('ERROR ' + contents.errorcode + ': ' + contents.errormessage);
-              } else {
-                  response = contents.results;
-                  response.ok = true;
-              }
-              res.send(response);
-            });
+                //Send the request
+                request(options, function (error, reqResponse, body) {
+                  if (error) throw new Error(error);
+                  var contents = JSON.parse(body);
+                  if (contents.error !== 0) {
+                    console.log('ERROR ' + contents.errorcode + ': ' + contents.errormessage);
+                  } else {
+                      cachedEventData = contents.results;
+                      response = contents.results;
+                      response.ok = true;
+                  }
+                  res.send(response);
+                });
+            // Cached data present
+            } else {
+                response = cachedEventData;
+                response.ok = true;
+                res.send(response);
+            }
 
         // Unknown query type
         } else {

--- a/controllers/events.js
+++ b/controllers/events.js
@@ -2,12 +2,7 @@ var express = require('express'),
     router = express.Router();
 var request = require('request');
 var fs = require('fs');
-
-// API keys to access the skiddle festival database
-// var contents = fs.readFileSync(__dirname + '/../config/api_keys.json');
-// var api_keys = JSON.parse(contents);
-
-var cachedEventData = null;
+var skiddleAPI = require(__dirname + '/../utils/skiddleAPI');
 
 // Serve requests to the event endpoint
 router.get('/event', function(req, res){
@@ -21,37 +16,7 @@ router.get('/event', function(req, res){
         // 'All' returns the entire events list
         if(req.query.type === "all") {
 
-            // Check to see if we've already cached the event data
-            if (!cachedEventData) {
-                //Get all events from Skiddle API
-                var options = { method: 'GET',
-                  url: process.env.skiddle_url  + 'events/',
-                  qs: 
-                   { eventcode: 'FEST',
-                     order: '4',
-                     api_key: process.env.skiddle_api_key } };
-
-                console.log("GET " + options.url);
-
-                //Send the request
-                request(options, function (error, reqResponse, body) {
-                  if (error) throw new Error(error);
-                  var contents = JSON.parse(body);
-                  if (contents.error !== 0) {
-                    console.log('ERROR ' + contents.errorcode + ': ' + contents.errormessage);
-                  } else {
-                      cachedEventData = contents.results;
-                      response = contents.results;
-                      response.ok = true;
-                  }
-                  res.send(response);
-                });
-            // Cached data present
-            } else {
-                response = cachedEventData;
-                response.ok = true;
-                res.send(response);
-            }
+            skiddleAPI.getAllEvents(res);
 
         // Unknown query type
         } else {

--- a/utils/skiddleAPI.js
+++ b/utils/skiddleAPI.js
@@ -1,0 +1,45 @@
+var request = require('request');
+
+var cachedEventData = null;
+
+var skiddleAPI = {
+
+	getAllEvents: function (res) {
+
+        // Check to see if we've already cached the event data
+        if (!cachedEventData) {
+
+            //Get all events from Skiddle API
+            var options = { method: 'GET',
+                url: process.env.skiddle_url  + 'events/',
+                qs: 
+                    { eventcode: 'FEST',
+                        order: '4',
+                        api_key: process.env.skiddle_api_key } };
+
+            console.log("GET " + options.url);
+
+            //Send the request
+            request(options, function (error, reqResponse, body) {
+                if (error) throw new Error(error);
+                var contents = JSON.parse(body);
+                if (contents.error !== 0) {
+                    console.log('ERROR ' + contents.errorcode + ': ' + contents.errormessage);
+                } else {
+                    cachedEventData = contents.results;
+                    response = contents.results;
+                    response.ok = true;
+                }
+                res.send(response);
+            });
+        // Cached data present
+        } else {
+            response = cachedEventData;
+            response.ok = true;
+            res.send(response);
+        }
+
+    }
+};
+
+module.exports = skiddleAPI;

--- a/utils/skiddleAPI.js
+++ b/utils/skiddleAPI.js
@@ -1,6 +1,14 @@
 var request = require('request');
 
-var cachedEventData = null;
+var cachedEventData = undefined;
+
+var defaultOptions = {
+    method: 'GET',
+    url: process.env.skiddle_url,
+    qs: {
+        api_key: process.env.skiddle_api_key
+    }
+};
 
 var skiddleAPI = {
 
@@ -10,28 +18,16 @@ var skiddleAPI = {
         if (!cachedEventData) {
 
             //Get all events from Skiddle API
-            var options = { method: 'GET',
-                url: process.env.skiddle_url  + 'events/',
-                qs: 
-                    { eventcode: 'FEST',
-                        order: '4',
-                        api_key: process.env.skiddle_api_key } };
+            var options = defaultOptions;
+            options.url += 'events/';
+            options.qs.eventcode = 'FEST';
+            options.qs.order = '4';
 
             console.log("GET " + options.url);
 
             //Send the request
-            request(options, function (error, reqResponse, body) {
-                if (error) throw new Error(error);
-                var contents = JSON.parse(body);
-                if (contents.error !== 0) {
-                    console.log('ERROR ' + contents.errorcode + ': ' + contents.errormessage);
-                } else {
-                    cachedEventData = contents.results;
-                    response = contents.results;
-                    response.ok = true;
-                }
-                res.send(response);
-            });
+            apiRequest(options, res);
+
         // Cached data present
         } else {
             response = cachedEventData;
@@ -41,5 +37,21 @@ var skiddleAPI = {
 
     }
 };
+
+// Function to call api with given options and endpoint
+function apiRequest(options, res) {
+    request(options, function (error, reqResponse, body) {
+        if (error) throw new Error(error);
+        var contents = JSON.parse(body);
+        if (contents.error !== 0) {
+            console.log('ERROR ' + contents.errorcode + ': ' + contents.errormessage);
+        } else {
+            cachedEventData = contents.results;
+            response = contents.results;
+            response.ok = true;
+        }
+        res.send(response);
+    });
+}
 
 module.exports = skiddleAPI;


### PR DESCRIPTION
- Object is created when Skiddle API is first hit, stopping unnecessary repeat requests.
- Broken all Skiddle API calls out from controllers/events to their own module
