### PR TITLE
Spotify Refresh Tokens Closes #71

### DIFF
--- a/controllers/spotify.js
+++ b/controllers/spotify.js
@@ -94,6 +94,7 @@ router.get('/spotify/callback', function (req, res) {
 // Get a new access token using refresh token
 // Previous one may have expired
 router.get('/spotify/refreshToken', function (req, res) {
+    
     console.log("GET /spotify/refreshToken");
     var response = {};
     response.ok = false;

--- a/controllers/spotify.js
+++ b/controllers/spotify.js
@@ -98,8 +98,9 @@ router.get('/spotify/refreshToken', function (req, res) {
     console.log("GET /spotify/refreshToken");
     var response = {};
     response.ok = false;
+    console.log(req.query.refresh_token);
     
-    spotifyAPI.refreshAccessToken(res.query.refresh_token, client_id, client_secret).then(function(accessToken){
+    spotifyAPI.refreshAccessToken(req.query.refresh_token, client_id, client_secret).then(function(accessToken){
         response.ok = true;
         response.accessToken = accessToken;
         res.send(response);

--- a/controllers/spotify.js
+++ b/controllers/spotify.js
@@ -30,10 +30,10 @@ var generateRandomString = function (length) {
 // Handle user wanting to auth with spotify
 // Requests auth token from spotity
 // Redirects user to spotify login page
-router.get('/spotifyLogin', function (req, res) {
+router.get('/spotify/login', function (req, res) {
 
     console.log("GET https://accounts.spotify.com/authorize?");
-    console.log("GET /spotifyLogin");
+    console.log("GET /spotify/login");
     
     // Generate a random state
     // The state can be useful for correlating requests and responses. Because your redirect_uri can
@@ -58,9 +58,9 @@ router.get('/spotifyLogin', function (req, res) {
 // Returns the auth code which we can use to ask for an access token
 // access token allows to to get user spotify information
 // TODO put this into spotify API file
-router.get('/spotifyCallback', function (req, res) {
+router.get('/spotify/callback', function (req, res) {
 
-    console.log("GET /spotifyCallback");
+    console.log("GET /spotify/callback");
     
     // your application requests refresh and access tokens
     // after checking the state parameter
@@ -73,7 +73,7 @@ router.get('/spotifyCallback', function (req, res) {
             querystring.stringify({
                 error: 'state_mismatch'
             }));
-    } else {        
+    } else {
 
         res.clearCookie(stateKey);
         
@@ -85,16 +85,33 @@ router.get('/spotifyCallback', function (req, res) {
                 
             // we can also pass the token to the browser to make requests from there
             res.redirect('/#');
-        }).catch(function(err){
+        }).catch(function (err) {
             res.redirect('/#' + querystring.stringify(err));
         });
     }
 });
 
-// Returns all artists contained in every playlist from the given user 
-router.get('/spotifyArtists', function (req, res) {
+// Get a new access token using refresh token
+// Previous one may have expired
+router.get('/spotify/refreshToken', function (req, res) {
+    console.log("GET /spotify/refreshToken");
+    var response = {};
+    response.ok = false;
+    
+    spotifyAPI.refreshAccessToken(res.query.refresh_token, client_id, client_secret).then(function(accessToken){
+        response.ok = true;
+        response.accessToken = accessToken;
+        res.send(response);
+    }).catch(function(err){
+        response.error = err;
+        res.send(response);
+    });
+});
 
-    console.log("GET /spotifyArtists");
+// Returns all artists contained in every playlist from the given user 
+router.get('/spotify/artists', function (req, res) {
+
+    console.log("GET /spotify/artists");
     var accessToken = "";
     
     // get the access token from cookie

--- a/controllers/spotify.js
+++ b/controllers/spotify.js
@@ -80,7 +80,7 @@ router.get('/spotify/callback', function (req, res) {
         // Request the access key using the auth code
         spotifyAPI.getAccessToken(code, redirect_uri, client_id, client_secret).then(function (tokens) {
             // Return access token in cookie to client
-            res.cookie('spotifyAccessCode', tokens.access_token);
+            res.cookie('spotifyAccessToken', tokens.access_token);
             res.cookie('spotifyRefreshToken', tokens.refresh_token);
                 
             // we can also pass the token to the browser to make requests from there
@@ -122,7 +122,7 @@ router.get('/spotify/artists', function (req, res) {
     for (var i = 0; i < cookies.length; i++) {
         var cookie = cookies[i];
         var value = cookie.split('=');
-        if (value[0] === 'spotifyAccessCode') {
+        if (value[0] === 'spotifyAccessToken') {
             accessToken = value[1];
         }
     }

--- a/public/app/directives/festvialTileDirective.js
+++ b/public/app/directives/festvialTileDirective.js
@@ -41,7 +41,7 @@ angular.module('festivalTileDirective', [])
                 
                 // Trim the eventname to fit on the cards
                 if (scope.event.eventname.length > 20) {
-                    scope.displayEventName = scope.event.eventname.substring(0, 20) + "...";
+                    scope.displayEventName = scope.event.eventname.substring(0, 17) + "...";
                 } else {
                     scope.displayEventName = scope.event.eventname;
                 }          

--- a/public/app/services/SpotifyService.js
+++ b/public/app/services/SpotifyService.js
@@ -59,7 +59,7 @@ angular.module('festerrApp').factory('SpotifyService', function ($q, $location, 
                     deferred.resolve(userArtists);
                 }).catch(function (err) {
                     deferred.reject(err);
-                    console.error("Error getting all artists");
+                    console.error("Error getting all artists: %o", err);
                 });
             } else {
                 deferred.resolve(userArtists);
@@ -84,7 +84,11 @@ angular.module('festerrApp').factory('SpotifyService', function ($q, $location, 
         var request = new Request(url, options);
 
         return fetch(request).then(function (res) {
-            return res.json();
+            if(res.ok){
+                return res.json();
+            } else {
+                throw new Error(res.statusText + ": " + res.status)
+            }
         });
     }
 

--- a/public/app/services/SpotifyService.js
+++ b/public/app/services/SpotifyService.js
@@ -44,13 +44,14 @@ angular.module('festerrApp').factory('SpotifyService', function ($q, $location, 
     // Only make network request if not already retrived artists
     function getAllArtists() {
         var deferred = $q.defer();
+        var methodURL = '/spotify/Artists?userID=';
         
         console.log("Getting spotify artists");
 
         getUserInfo().then(function (userInfo) {
             // only make request if we don't already have the data
             if (userArtists.length === 0) {
-                call('/spotifyArtists?userID=' + userInfo.id, {
+                call(methodURL + userInfo.id, {
                     method: 'get',
                     credentials: 'include'
                 }).then(function (res) {

--- a/public/app/services/SpotifyService.js
+++ b/public/app/services/SpotifyService.js
@@ -61,6 +61,8 @@ angular.module('festerrApp').factory('SpotifyService', function ($q, $location, 
                 }).catch(function (err) {
                     deferred.reject(err);
                     console.error("Error getting all artists: %o", err);
+                    
+                    // get new access token
                 });
             } else {
                 deferred.resolve(userArtists);
@@ -88,7 +90,17 @@ angular.module('festerrApp').factory('SpotifyService', function ($q, $location, 
             if(res.ok){
                 return res.json();
             } else {
-                throw new Error(res.statusText + ": " + res.status)
+                if(res.status === 401) {
+                    console.error("Unath spotify access, getting new access token");  
+                    // get new access token
+                    var refeshToken = $cookies.get('spotifyRefreshToken');
+                    var methodURL = '/spotify/refreshToken?refresh_token=' + refeshToken;
+                    call(methodURL, {}).then(function(res){
+                        console.log(res);
+                    });
+                                      
+                }
+                throw new Error(res)
             }
         });
     }

--- a/public/app/views/header/header.html
+++ b/public/app/views/header/header.html
@@ -1,21 +1,13 @@
-<div id="top-header" ng-controller="HeaderCtrl">  
+<div id="top-header" ng-controller="HeaderCtrl">
     <div id="header-text-container">
-    <h1>Festerr</h1>               
+        <h1>Festerr</h1>
     </div>
-    
+
     <div id="header-search-box-container">
-        <md-chips
-            ng-model="selectedChips"
-            md-autocomplete-snap=""
-            md-require-match="true">
-            <md-autocomplete id="search-autocomplete"
-                md-selected-item="selectedChip"
-                md-search-text="searchText"
-                md-items="item in asyncChipSearch(searchText)"
-                md-item-text="item.name"
-                placeholder="Search for a festival, artist or event">
-                <span
-                    md-highlight-text="searchText">
+        <md-chips ng-model="selectedChips" md-autocomplete-snap="" md-require-match="true">
+            <md-autocomplete id="search-autocomplete" md-selected-item="selectedChip" md-search-text="searchText" md-items="item in asyncChipSearch(searchText)"
+            md-item-text="item.name" placeholder="Search for a festival, artist or event">
+                <span md-highlight-text="searchText">
                     {{item.name}}
                 </span>
             </md-autocomplete>
@@ -26,25 +18,25 @@
                 </span>
             </md-chip-template>
         </md-chips>
-    </div> 
-    
+    </div>
+
     <div id="header-user-login-container" ng-hide="spotifyCodeExists">
         <md-button class="md-raised" ng-click="showSignupDialog($event)">Register</md-button>
-    </div>  
+    </div>
     <div id="header-spotify-authed-container" ng-show="spotifyCodeExists">
         {{spotifyUserInfo.short_name}}
-        <div id="header-spotify-user-profile" style="background-image:url({{spotifyUserInfo.images[0].url}})">            
+        <div id="header-spotify-user-profile" style="background-image:url({{spotifyUserInfo.images[0].url}})">
         </div>
-    </div>  
-    
+    </div>
+
     <div id="header-tabs-container">
         <md-tabs md-dynamic-height md-border-bottom>
-        <md-tab label="What's Hot">
-        </md-tab>
-        <md-tab label="Upcoming">                    
-        </md-tab>
-        <md-tab label="Favourites">                    
-        </md-tab>
+            <md-tab label="What's Hot">
+            </md-tab>
+            <md-tab label="Upcoming">
+            </md-tab>
+            <md-tab label="Favourites">
+            </md-tab>
         </md-tabs>
     </div>
 </div>

--- a/public/app/views/header/header.js
+++ b/public/app/views/header/header.js
@@ -33,7 +33,7 @@ function HeaderController($scope, $mdDialog, $cookies, SpotifyService) {
     };
     
     // Check if spotify code exists, and get user info if true
-    var accessCode = $cookies.get('spotifyAccessCode');
+    var accessCode = $cookies.get('spotifyAccessToken');
     if (accessCode) {
         console.log("already have a spotify code in cookies");
         $scope.spotifyCodeExists = true;

--- a/public/app/views/header/signupDialog.html
+++ b/public/app/views/header/signupDialog.html
@@ -7,7 +7,7 @@
             <p>
                 Festerr uses your Spotify library to show events that matter to you. Festivals featuring more artists in your library appear higher than those with less. Click login with Spotify below to get started!
             </p>
-            <a href="/spotifyLogin">
+            <a href="/spotify/login">
                 <div id="signup-dialog-spotify-container">
                     <img src="images/log_in-desktop-large.png" id="signin-spotify">
                 </div>

--- a/public/css/festivalCard.css
+++ b/public/css/festivalCard.css
@@ -21,6 +21,14 @@
     height: 100%;
 }
 
+.festival-card-image{
+    display: flex;
+    flex-flow: row;
+    align-content: space-between;
+    justify-content: space-around;
+    align-items: flex-end;
+}
+
 .festival-card.festival-details{
     /*height: 100%;*/
     background-color: #446CB3;
@@ -34,6 +42,16 @@
     /*transition: all 2s;*/
 }
 
+.festival-card-image-text {
+    width: 100%;
+    display: flex;
+    flex-flow: row;
+    justify-content: space-around;
+    align-items: center;
+    color:white;
+    font-size: larger;
+}
+
 .festival-card-details {
     padding: 20px;
 }
@@ -45,7 +63,8 @@
 }
 
 .md-headline {
-    font-size: medium;
+    font-size: larger;
+    /*color: white;*/
 }
 
 md-card-title {

--- a/public/images/heart_white.svg
+++ b/public/images/heart_white.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="48" viewBox="0 0 24 24" width="48" xmlns="http://www.w3.org/2000/svg">
+<svg fill="#FFFFFF" height="48" viewBox="0 0 24 24" width="48" xmlns="http://www.w3.org/2000/svg">
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
 </svg>

--- a/public/templates/eventTile.html
+++ b/public/templates/eventTile.html
@@ -1,22 +1,19 @@
 <div class="festival-container" style="margin-top:{{topMargin}}px; margin-bottom:{{bottomMargin}}px; width:{{containerWidth}}">
     <div class="festival-card-container" style="height:{{displayHeight}}px; width:{{festivalCardWidth}}%">
         <md-card class="festival-card">
-            <div class="festival-card-image md-card-image" style="background-image: url('{{event.largeimageurl}}');" ng-click="selectEventTile(event.tileInfo)">
-            </div>
-            <md-card-actions layout="row" layout-align="end center">
-                <div style="width=80%">
+            <div class="festival-card-image md-card-image" style="background: linear-gradient(to top, rgba(0,0,0,0.55) 0%,rgba(0,0,0,0) 25%), url('{{event.largeimageurl}}'); background-size: cover;"
+            ng-click="selectEventTile(event.tileInfo)">
+                <div class='festival-card-image-text'>
                     <md-card-title-text>
                         <span class="md-headline" ng-hide="isExpanded">{{displayEventName}}</span>
                         <span class="md-headline" ng-show="isExpanded">{{event.eventname}}</span>
                     </md-card-title-text>
-                </div>
-                <div>
                     {{spotifyArtists.length}}
                     <md-button class="md-icon-button" aria-label="Favorite">
-                        <md-icon md-svg-icon="images/heart_gray.svg"></md-icon>
+                        <md-icon md-svg-icon="images/heart_white.svg"></md-icon>
                     </md-button>
                 </div>
-            </md-card-actions>
+            </div>
             <div class="festival-card-details" ng-show="isExpanded">
                 <p style="width:100%"> {{event.description}}</p>
                 <div class="info-line">

--- a/server.js
+++ b/server.js
@@ -26,9 +26,8 @@ app.get('/', function (req, res) {
 
 // Serve /event 
 app.get('/event', require("./controllers/events.js"));
-app.get('/spotifyLogin', require('./controllers/spotify'));
-app.get('/spotifyCallback', require('./controllers/spotify'));
-app.get('/spotifyArtists', require('./controllers/spotify'));
+app.get('/spotify/*', require('./controllers/spotify'));
+
 // Example query for google image search
 // var query = imageSearch.buildImageQuery("Strawberries and cream festival 2016");
 // var imageSearchResult = imageSearch.makeRequest(query).then(function(res){

--- a/utils/SpotifyAPI.js
+++ b/utils/SpotifyAPI.js
@@ -78,7 +78,6 @@ var spotifyAPI = {
         
         // Send the request, then redirect the auth code to our client browser
         // TODO store the user access code
-        // TODO handle refreshing access codes
         request.post(authOptions, function (error, response, body) {
             if (!error && response.statusCode === 200) {
                 var access_token = body.access_token,
@@ -96,6 +95,30 @@ var spotifyAPI = {
         });
 
         return deferred.promise;
+    },
+    
+    // Request a new access token
+    // Requires an existing fresh token
+    refreshAccessToken: function (refresh_token, client_id, client_secret) {
+        var deferred = q.defer();
+        
+        var authOptions = {
+            url: 'https://accounts.spotify.com/api/token',
+            headers: { 'Authorization': 'Basic ' + (new Buffer(client_id + ':' + client_secret).toString('base64')) },
+            form: {
+                grant_type: 'refresh_token',
+                refresh_token: refresh_token
+            },
+            json: true
+        };
+
+        request.post(authOptions, function (error, response, body) {
+            if (!error && response.statusCode === 200) {
+                deferred.resolve(body.access_token);
+            } else {
+                deferred.rejct(body);
+            }
+        });
     }
 };
 

--- a/utils/SpotifyAPI.js
+++ b/utils/SpotifyAPI.js
@@ -116,9 +116,11 @@ var spotifyAPI = {
             if (!error && response.statusCode === 200) {
                 deferred.resolve(body.access_token);
             } else {
-                deferred.rejct(body);
+                deferred.reject(body);
             }
         });
+        
+        return deferred.promise;
     }
 };
 


### PR DESCRIPTION
- Change closed festival card design to use gradient instead of white background for text
- Rename spotify endpoints to /spotify/\* in routers
- change cookie name to spotifyAccessToken
- Add refresh token flow if access code runs out (not tested, have to wait for timeout to happen)
- GET NEW setEnvVars file
