### PR TITLE
Spotify Event Tile Sorting, closes #59, closes #61, closes #75

### DIFF
--- a/public/app/directives/festvialTileDirective.js
+++ b/public/app/directives/festvialTileDirective.js
@@ -29,15 +29,7 @@ angular.module('festivalTileDirective', [])
                 scope.bottomMargin = defaultMargin;
                 scope.showDetails = false;
                 scope.containerWidth = "300px";
-                scope.festivalCardWidth = 100;
-                scope.spotifyArtists = [];
-                
-                // watch artist list as retreived async from spotify
-                scope.$watch('artistList', function (newVal, oldVal) {
-                    if (newVal) {
-                        findSpotifyArtistsInFestival(newVal);
-                    }
-                }, true);             
+                scope.festivalCardWidth = 100;            
                 
                 // Trim the eventname to fit on the cards
                 if (scope.event.eventname.length > 20) {
@@ -107,15 +99,7 @@ angular.module('festivalTileDirective', [])
                     scope.containerWidth = "100%";
                     scope.festivalCardWidth = expandedWidth;
                 };
-                
-                // Find all spotify artists who are also in this events artist list
-                function findSpotifyArtistsInFestival(spotifyArtists) {
-                    if (spotifyArtists.length > 0) {
-                        scope.spotifyArtists = scope.event.artists.filter(function (eventArtist) {
-                            return (spotifyArtists.indexOf(eventArtist.name) !== -1);
-                        });
-                    }
-                }
+            
             }
         };
     });

--- a/public/app/views/festivalList/festivalList.js
+++ b/public/app/views/festivalList/festivalList.js
@@ -61,6 +61,21 @@ angular.module('FestivalListView', ['ngMaterial'])
                 
                 // Set user artist list in directive
                 $scope.userArtistList = userArtists;
+
+                if (userArtists.length !== 0) {
+                    for (var i = $scope.eventList.length - 1; i >= 0; i--) {
+                        $scope.eventList[i].spotifyArtists = $scope.eventList[i].artists.filter(function (eventArtist) {
+                            return ($scope.userArtistList.indexOf(eventArtist.name) !== -1);
+                        });
+                        $scope.eventList[i].artists = $scope.eventList[i].artists.filter(function (eventArtist) {
+                            return ($scope.userArtistList.indexOf(eventArtist.name) === -1);
+                        });
+                    }
+
+                    $scope.eventList.sort(function (a, b) {
+                        return b.spotifyArtists.length - a.spotifyArtists.length;
+                    });
+                }
                 
                 // Show the loading icon for 0.5s before showing content
                 $interval(function () {

--- a/public/app/views/festivalList/festivalList.js
+++ b/public/app/views/festivalList/festivalList.js
@@ -62,7 +62,9 @@ angular.module('FestivalListView', ['ngMaterial'])
                 // Set user artist list in directive
                 $scope.userArtistList = userArtists;
 
+                //Only need to calculate user artists if there are any
                 if (userArtists.length !== 0) {
+                    //Break event artist list into ones from the user's spotify and the rest
                     for (var i = $scope.eventList.length - 1; i >= 0; i--) {
                         $scope.eventList[i].spotifyArtists = $scope.eventList[i].artists.filter(function (eventArtist) {
                             return ($scope.userArtistList.indexOf(eventArtist.name) !== -1);
@@ -72,6 +74,7 @@ angular.module('FestivalListView', ['ngMaterial'])
                         });
                     }
 
+                    //Sort the events list by number of spotify artists present
                     $scope.eventList.sort(function (a, b) {
                         return b.spotifyArtists.length - a.spotifyArtists.length;
                     });

--- a/public/templates/eventTile.html
+++ b/public/templates/eventTile.html
@@ -44,7 +44,7 @@
             </md-toolbar>
             <md-content flex layout-padding style="height: 486px;">
                 <md-list>
-                    <md-subheader class="md-sticky">Your Artists ({{event.spotifyArtists.length}})</md-subheader>
+                    <md-subheader class="md-no-sticky">Your Artists ({{event.spotifyArtists.length}})</md-subheader>
                     <md-list-item class="md-2-line" ng-repeat="artist in event.spotifyArtists | limitTo:20">
                         <img ng-src="{{artist.image}}?20" class="md-avatar" />
                         <div class="md-list-item-text">
@@ -52,7 +52,7 @@
                             <p>Secondary text</p>
                         </div>
                     </md-list-item>
-                    <md-subheader class="md-sticky">Other Artists ({{event.artists.length}})</md-subheader>
+                    <md-subheader class="md-no-sticky">Other Artists ({{event.artists.length}})</md-subheader>
                     <md-list-item class="md-2-line" ng-repeat="artist in event.artists | limitTo:20">
                         <img ng-src="{{artist.image}}?20" class="md-avatar" />
                         <div class="md-list-item-text">

--- a/public/templates/eventTile.html
+++ b/public/templates/eventTile.html
@@ -41,7 +41,7 @@
             </md-toolbar>
             <md-content flex layout-padding style="height: 486px;">
                 <md-list>
-                    <md-subheader class="md-no-sticky">Your Artists ({{event.spotifyArtists.length}})</md-subheader>
+                    <md-subheader ng-show="event.spotifyArtists.length" class="md-no-sticky">Your Artists ({{event.spotifyArtists.length}})</md-subheader>
                     <md-list-item class="md-2-line" ng-repeat="artist in event.spotifyArtists | limitTo:20">
                         <img ng-src="{{artist.image}}?20" class="md-avatar" />
                         <div class="md-list-item-text">

--- a/public/templates/eventTile.html
+++ b/public/templates/eventTile.html
@@ -11,7 +11,7 @@
                     </md-card-title-text>
                 </div>
                 <div>
-                    {{spotifyArtists.length}}
+                    {{event.spotifyArtists.length}}
                     <md-button class="md-icon-button" aria-label="Favorite">
                         <md-icon md-svg-icon="images/heart_gray.svg"></md-icon>
                     </md-button>
@@ -39,12 +39,20 @@
         <div class="festival-card festival-details" md-whiteframe="6" ng-show="isExpanded">
             <md-toolbar class="md-warn">
                 <div class="md-toolbar-tools">
-                    <h2 class="md-flex">Event Toolbar</h2>
+                    <h2 class="md-flex">Appearing Artists</h2>
                 </div>
             </md-toolbar>
             <md-content flex layout-padding style="height: 486px;">
                 <md-list>
-                    <md-subheader class="md-sticky">Appearing Artists ({{event.artists.length}})</md-subheader>
+                    <md-subheader class="md-sticky">Your Artists ({{event.spotifyArtists.length}})</md-subheader>
+                    <md-list-item class="md-2-line" ng-repeat="artist in event.spotifyArtists | limitTo:20">
+                        <img ng-src="{{artist.image}}?20" class="md-avatar" />
+                        <div class="md-list-item-text">
+                            <h3>{{ artist.name }}</h3>
+                            <p>Secondary text</p>
+                        </div>
+                    </md-list-item>
+                    <md-subheader class="md-sticky">Other Artists ({{event.artists.length}})</md-subheader>
                     <md-list-item class="md-2-line" ng-repeat="artist in event.artists | limitTo:20">
                         <img ng-src="{{artist.image}}?20" class="md-avatar" />
                         <div class="md-list-item-text">


### PR DESCRIPTION
- Event tiles are now sorted by the number of artists playing that the user has in their Spotify playlists.
- The 'Appearing Artists' header no longer appears at the top
- Each event detail now shows which artists are playing that the user has in their Spotify playlists.
