### PR TITLE
Fix spotify startup logic

### DIFF
--- a/controllers/spotify.js
+++ b/controllers/spotify.js
@@ -99,11 +99,11 @@ router.get('/spotify/refreshToken', function (req, res) {
     console.log("GET /spotify/refreshToken");
     var response = {};
     response.ok = false;
-    console.log(req.query.refresh_token);
     
-    spotifyAPI.refreshAccessToken(req.query.refresh_token, client_id, client_secret).then(function(accessToken){
+    spotifyAPI.refreshAccessToken(req.query.refresh_token, client_id, client_secret).then(function(spotifyRes){
         response.ok = true;
-        response.accessToken = accessToken;
+        response.accessToken = spotifyRes.access_token;
+        response.expire_at = spotifyRes.expire_at;
         res.send(response);
     }).catch(function(err){
         response.error = err;

--- a/public/app/app.js
+++ b/public/app/app.js
@@ -1,2 +1,16 @@
 angular.module('festerrApp', [
-    'FestivalListView', 'HeaderView',  'festivalTileDirective']);
+    'MainView', 'FestivalListView', 'HeaderView', 'ngRoute', 'festivalTileDirective']).config(function ($routeProvider) {
+        
+        $routeProvider.when('/', {
+            controller: 'MainCtrl',
+            templateUrl: '/templates/bodyTemplate.html',
+            resolve: {
+                'SpotifyServiceSetup': function(SpotifyService){
+                    // main controller won't be instanciated until this promise resolves
+                    // allows us to do spoitfy setup beofre anything else happens
+                    return SpotifyService.setup();
+                }
+            }
+        });
+
+    });

--- a/public/app/views/mainController.js
+++ b/public/app/views/mainController.js
@@ -1,0 +1,7 @@
+angular.module('MainView', [])
+    .controller('MainCtrl', ['$scope', 'SpotifyService', MainController]);
+    
+function MainController($scope, SpotifyService) {
+    console.info("SPOTIFY SETUP");
+}
+

--- a/public/templates/bodyTemplate.html
+++ b/public/templates/bodyTemplate.html
@@ -1,0 +1,8 @@
+<div id="main-container" ng-controller="FestivalListCtrl">
+
+    <!-- header -->
+    <ng-include src="'/app/views/header/header.html'"></ng-include>
+    <!-- Main festival list -->
+    <ng-include src="'/app/views/festivalList/festivalList.html'"></ng-include>
+
+</div>

--- a/utils/SpotifyAPI.js
+++ b/utils/SpotifyAPI.js
@@ -87,7 +87,7 @@ var spotifyAPI = {
                 // get the expiry time for the client to know when to get new one
                 // do it a bit earlier than needed to be safe
                 var expire_at = Math.floor(Date.now() / 1000) + (expires_in - (10 * 60));
-                
+
                 deferred.resolve({
                     access_token: access_token,
                     refresh_token: refresh_token,
@@ -107,7 +107,7 @@ var spotifyAPI = {
     // Requires an existing fresh token
     refreshAccessToken: function (refresh_token, client_id, client_secret) {
         var deferred = q.defer();
-        
+
         var authOptions = {
             url: 'https://accounts.spotify.com/api/token',
             headers: { 'Authorization': 'Basic ' + (new Buffer(client_id + ':' + client_secret).toString('base64')) },
@@ -120,12 +120,23 @@ var spotifyAPI = {
 
         request.post(authOptions, function (error, response, body) {
             if (!error && response.statusCode === 200) {
-                deferred.resolve(body.access_token);
+                var access_token = body.access_token,
+                    expires_in = body.expires_in;
+                
+                // get the expiry time for the client to know when to get new one
+                // do it a bit earlier than needed to be safe
+                var expire_at = Math.floor(Date.now() / 1000) + (expires_in - (10 * 60));
+                
+                deferred.resolve({
+                    access_token: access_token,
+                    expire_at: expire_at
+                });
+
             } else {
                 deferred.reject(body);
             }
         });
-        
+
         return deferred.promise;
     }
 };

--- a/views/index.html
+++ b/views/index.html
@@ -25,14 +25,8 @@
 
 	<body ng-app="festerrApp">
         
-    <div id="main-container" ng-controller="FestivalListCtrl">
-
-        <!-- header -->
-        <ng-include src="'/app/views/header/header.html'"></ng-include>
-        <!-- Main festival list -->
-        <ng-include src="'/app/views/festivalList/festivalList.html'"></ng-include>    
-
-    </div>   
+        <ng-view></ng-view>
+    
 	</body>
 
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/fabric.js/1.5.0/fabric.min.js"></script>
@@ -41,12 +35,14 @@
 	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/2.0.0/mustache.min.js"></script>
 	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.9/angular.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.9/angular-animate.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.9/angular-route.js"></script>
     <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.9/angular-cookies.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.9/angular-aria.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angular_material/0.9.4/angular-material.min.js"></script>
 
 	<script type="text/javascript" src="js/FesterrMap.js"></script>
 	<script type="text/javascript" src="app/app.js"></script>
+    <script type="text/javascript" src="app/views/mainController.js"></script>
 	<script type="text/javascript" src="app/views/festivalList/festivalList.js"></script>
     <script type="text/javascript" src="app/views/header/header.js"></script>
 	<script type="text/javascript" src="app/services/FestivalDataService.js"></script>


### PR DESCRIPTION
- add startup logic to main app, only instantiates  the main controller (and hence the rest of the controllers as they are now inside the main controller's scope in ng-view) once SpotifyService has validated the accessToken
- This prevents race conditions where Spotify requests would fail before access codes had a chance to refresh
-  The config to app.js says when we load '/', load the main controller using the body template, but only when resolve has finished, i.e when Spotify.Steup() has resolved successfully
- Also send expirey time when getting a new token
