### PR TITLE
Sessions

### DIFF
--- a/controllers/events.js
+++ b/controllers/events.js
@@ -18,7 +18,8 @@ router.get('/event', function(req, res) {
         // just return a single events detail
         else if (req.query.type = "single") {
             
-            console.log(req.session.userID);
+            // We can now access the user session if it exists
+            // console.log(req.session.userID);
             
             // Use event id from the query string
             if (req.query.id !== undefined) {

--- a/controllers/events.js
+++ b/controllers/events.js
@@ -1,7 +1,5 @@
 var express = require('express'),
     router = express.Router();
-var request = require('request');
-var fs = require('fs');
 var skiddleAPI = require(__dirname + '/../utils/skiddleAPI');
 
 // Serve requests to the event endpoint
@@ -19,6 +17,9 @@ router.get('/event', function(req, res) {
         }
         // just return a single events detail
         else if (req.query.type = "single") {
+            
+            console.log(req.session.userID);
+            
             // Use event id from the query string
             if (req.query.id !== undefined) {
                 skiddleAPI.getSingleEvent(req.query.id).then(function(response) {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "dependencies": {
     "body-parser": "^1.12.4",
+    "client-sessions": "^0.7.0",
     "cookie-parser": "^1.3.5",
     "debug": "^2.2.0",
     "ejs": "^2.3.1",

--- a/public/app/services/FestivalDataService.js
+++ b/public/app/services/FestivalDataService.js
@@ -10,12 +10,11 @@ angular.module('festerrApp').factory('FestivalDataService', function($q, Network
     var getFestivalData = function() {
         var deferred = $q.defer();
 
-        NetworkService.callAPI({
-            url: '/event/?type=all',
+        NetworkService.callAPI('/event/?type=all', {
             method: 'GET'
-        }).then(function(res){
+        }).then(function(res) {
             deferred.resolve(res);
-        }).catch(function(err){
+        }).catch(function(err) {
             deferred.reject(err);
         });
 

--- a/public/app/services/NetworkService.js
+++ b/public/app/services/NetworkService.js
@@ -2,12 +2,12 @@ angular.module('festerrApp').factory('NetworkService', function($q) {
     
     // Calls the api with a given request
     // Returns the josn of the response
-    function callAPI(request){
+    function callAPI(url, options){
         var deferred = $q.defer();
+        
+        var request = new Request(url, options);        
 
-        fetch(request.url, {
-            method: request.method
-        }).then(function(response){
+        fetch(request).then(function(response){
             deferred.resolve(response.json());
         }).catch(function(err){
             console.error(err);

--- a/public/app/services/NetworkService.js
+++ b/public/app/services/NetworkService.js
@@ -19,9 +19,5 @@ angular.module('festerrApp').factory('NetworkService', function($q) {
 
     return {
         callAPI: callAPI
-    }
-
-
- 
-
+    };
 });

--- a/public/app/services/SpotifyService.js
+++ b/public/app/services/SpotifyService.js
@@ -4,6 +4,14 @@ angular.module('festerrApp').factory('SpotifyService', function($q, $location, $
     var userInfo = {};
     var userArtists = [];
     var refreshTokenTimer;
+    
+    return {
+        getUserInfo: getUserInfo,
+        getAllArtists: getAllArtists,
+        filterUserArtists: filterUserArtists,
+        refreshAccessToken: refreshAccessToken,
+        setup: setup
+    };
 
     // Returns user's spotify info
     function getUserInfo() {
@@ -186,13 +194,5 @@ angular.module('festerrApp').factory('SpotifyService', function($q, $location, $
             setrefreshTokenTimer();
         });
     }
-
-    return {
-        getUserInfo: getUserInfo,
-        getAllArtists: getAllArtists,
-        filterUserArtists: filterUserArtists,
-        refreshAccessToken: refreshAccessToken,
-        setup: setup
-    };
 
 });

--- a/public/app/services/SpotifyService.js
+++ b/public/app/services/SpotifyService.js
@@ -1,10 +1,10 @@
-angular.module('festerrApp').factory('SpotifyService', function($q, $location, $cookies, $interval) {
+angular.module('festerrApp').factory('SpotifyService', function($q, $location, $cookies, $interval, NetworkService) {
 
     var userID = undefined;
     var userInfo = {};
     var userArtists = [];
     var refreshTokenTimer;
-    
+
     return {
         getUserInfo: getUserInfo,
         getAllArtists: getAllArtists,
@@ -55,7 +55,7 @@ angular.module('festerrApp').factory('SpotifyService', function($q, $location, $
     function getAllArtists() {
         var deferred = $q.defer();
         var methodURL = '/spotify/Artists?userID=';
-        
+
         getUserInfo().then(function(userInfo) {
             // only make request if we don't already have the data
             if (userArtists.length === 0) {
@@ -113,27 +113,23 @@ angular.module('festerrApp').factory('SpotifyService', function($q, $location, $
         return deferred.promise;
     }
 
-
-
-    // Calls a given url with opens
-    // Returns the json response
+    /* 
+        Calls a given url with options
+        Returns the json response
+    */
     function call(url, options) {
-
+        
         // Add cookies only when no other cookie options set
         if (options.credentials === undefined) {
             options.credentials = 'include'; //send the cookies with spotify access code
         }
 
-        var request = new Request(url, options);
-
-        return fetch(request).then(function(res) {
-            if (res.ok) {
-                return res.json();
-            } else {
-                if (res.status === 401) {
-                    console.error("Unath spotify access, need new access token");
-                }
+        return NetworkService.callAPI(url, options).then(function(res) {
+            if (res.status === 401 || res.ok === false) {
+                console.error("Unath spotify access, need new access token");
                 throw res;
+            } else {
+                return res;
             }
         });
     }

--- a/public/app/services/SpotifyService.js
+++ b/public/app/services/SpotifyService.js
@@ -144,8 +144,7 @@ angular.module('festerrApp').factory('SpotifyService', function($q, $location, $
             // If token has run out or about to (5 mins), get new one
             if (accessTokenTimeLeft() < (5 * 60)) {
                 console.info("NEEDED NEW TOKEN");
-                return refreshAccessToken().then(function(res) {
-                });
+                refreshAccessToken();
             } {
                 deferred.resolve();
                 return deferred.promise;

--- a/public/app/views/eventDetail/eventDetail.js
+++ b/public/app/views/eventDetail/eventDetail.js
@@ -18,13 +18,15 @@ function EventDetailController($scope, $q, NetworkService, $location, SpotifySer
     // Filter the artist data into two groups
     function getEventDetails(eventID) {
         
-        var query = {
-            url: "/event?type=single&id=" + eventID,
-            method: "GET"
+        // Create the request
+        var url = "/event?type=single&id=" + eventID;
+        var options = {
+            method: 'GET',
+            credentials: 'include'
         };
         
         // Get artist data then filter it
-        NetworkService.callAPI(query).then(function(res) {
+        NetworkService.callAPI(url, options).then(function(res) {
             if (res.ok) {
                 $scope.event = res.event;
                 // filter the artists in the event 

--- a/server.js
+++ b/server.js
@@ -1,7 +1,10 @@
 var express = require('express');
 var request = require('request');
 var fs = require('fs');
-var imageSearch = require('./utils/googleImageSearch');
+var secretString = "9t6aHMrAauERxkR";
+var sessions = require("client-sessions");
+
+var app = express();
 
 if(process.env.mode === "PROD"){
     // the env vars are already set
@@ -10,11 +13,16 @@ if(process.env.mode === "PROD"){
     var init = require('./config/setEnvVars.js');  
 }
 
-
-var app = express();
-
 // All static filss are in the public folder
 app.use(express.static(__dirname + '/public'));
+
+// Set session middlewear configuration
+app.use(sessions({
+  cookieName: 'session',
+  secret: secretString,
+  duration: 30 * 60 * 1000,
+  activeDuration: 5 * 60 * 1000,
+}));
 
 //used to display the html files
 app.engine('.html', require('ejs').renderFile);

--- a/utils/SpotifyAPI.js
+++ b/utils/SpotifyAPI.js
@@ -32,8 +32,10 @@ var spotifyAPI = {
     // Returns all promise that gives artists in every playlist for a given user    
     getAllArtists: function (accessToken, userID) {
         var artists = [];
+        var resourceURL;
+        
         // Get user playlists
-        var resourceURL = 'users/' + userID + '/playlists';
+        resourceURL = 'users/' + userID + '/playlists';
         
         // get playlists first, then gets artists from each
         return makeSpotifyRequest(resourceURL, accessToken).then(function (playlists) {
@@ -138,6 +140,16 @@ var spotifyAPI = {
         });
 
         return deferred.promise;
+    },
+    
+    // Gets the spotify user info for a user identified by the access token
+    getUserInfo: function(access_token){
+        var resourceURL = 'me';
+        
+        return makeSpotifyRequest(resourceURL, access_token).then(function(userData){
+            console.log(userData);
+            return userData;
+        });
     }
 };
 

--- a/utils/SpotifyAPI.js
+++ b/utils/SpotifyAPI.js
@@ -147,7 +147,6 @@ var spotifyAPI = {
         var resourceURL = 'me';
         
         return makeSpotifyRequest(resourceURL, access_token).then(function(userData){
-            console.log(userData);
             return userData;
         });
     }


### PR DESCRIPTION
- Add sessions middlewear to handle user id in cookie session
  - Does all the encryption/decrypt for us
- Set the session user id when the user logs into spotify
- will use this id as the key to db entries
- Refactor spotify service to use the network service api
  - Network service now sends cookies by default
